### PR TITLE
chore: update GitHub Actions to Node 22 versions

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -8,9 +8,9 @@ jobs:
         steps:
             -   name: Enable Corepack
                 run: corepack enable
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Use Node.js 24.x
-                uses: actions/setup-node@v4
+                uses: actions/setup-node@v6
                 with:
                     node-version: '24.x'
                     cache: 'yarn'
@@ -19,7 +19,7 @@ jobs:
             -   name: Build packages
                 run: yarn build
             -   name: Save build artifacts
-                uses: actions/cache/save@v4
+                uses: actions/cache/save@v5
                 with:
                     path: packages/*/dist
                     key: build-${{ github.sha }}
@@ -31,14 +31,14 @@ jobs:
         steps:
             -   name: Enable Corepack
                 run: corepack enable
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Restore build artifacts
-                uses: actions/cache/restore@v4
+                uses: actions/cache/restore@v5
                 with:
                     path: packages/*/dist
                     key: build-${{ github.sha }}
             -   name: Use Node.js 24.x
-                uses: actions/setup-node@v4
+                uses: actions/setup-node@v6
                 with:
                     node-version: '24.x'
                     cache: 'yarn'
@@ -54,14 +54,14 @@ jobs:
         steps:
             -   name: Enable Corepack
                 run: corepack enable
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Restore build artifacts
-                uses: actions/cache/restore@v4
+                uses: actions/cache/restore@v5
                 with:
                     path: packages/*/dist
                     key: build-${{ github.sha }}
             -   name: Use Node.js 24.x
-                uses: actions/setup-node@v4
+                uses: actions/setup-node@v6
                 with:
                     node-version: '24.x'
                     cache: 'yarn'
@@ -74,7 +74,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Check for changeset
                 run: |
                     count=$(find .changeset -maxdepth 1 -name "*.md" ! -name "README.md" | wc -l)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
         steps:
             -   name: Enable Corepack
                 run: corepack enable
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Use Node.js 24.x
-                uses: actions/setup-node@v4
+                uses: actions/setup-node@v6
                 with:
                     node-version: '24.x'
                     registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
         steps:
             -   name: Enable Corepack
                 run: corepack enable
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Use Node.js 24.x
-                uses: actions/setup-node@v4
+                uses: actions/setup-node@v6
                 with:
                     node-version: '24.x'
             -   name: Install dependencies


### PR DESCRIPTION
Bumps checkout@v4→v6, setup-node@v4→v6, cache@v4→v5 to resolve Node 20 deprecation warnings.