### PR TITLE
feat(esbuild): add @mochi-css/esbuild plugin and tsuki preset

### DIFF
--- a/.changeset/esbuild-adapter.md
+++ b/.changeset/esbuild-adapter.md
@@ -1,0 +1,6 @@
+---
+"@mochi-css/esbuild": minor
+"@mochi-css/tsuki": minor
+---
+
+Add `@mochi-css/esbuild` plugin for standalone library builds. Supports virtual CSS mode (default) and external CSS mode (`externalCss: true`) for distributing component libraries to Vite/Next.js consumers. Adds a matching `esbuild` preset to `tsuki`.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Detailed documentation about different parts of Mochi.css can be found here:
 - [**@mochi-css/postcss**](packages/postcss/README.md) - postcss plugin
 - [**@mochi-css/next**](packages/next/README.md) - Next.js plugin
 - [**@mochi-css/vite**](packages/vite/README.md) - Vite plugin
+- [**@mochi-css/esbuild**](packages/esbuild/README.md) - esbuild plugin
 - [**@mochi-css/builder**](packages/builder/README.md) - utilities for extracting styles from source code and generating CSS from them
 
 ---
@@ -78,12 +79,28 @@ Detailed documentation about different parts of Mochi.css can be found here:
 ## 🌱 Project Status
 
 **Early release** – starting with version 3, new features and improvements will be added while preserving code compatibility within the same major version.
-This guarantees that package upgrades within the same major version will not break your code, as long as you don't rely on bugs existing in the previous versions.
+This guarantees that package upgrades within the same major version will not break your code,
+as long as you don't rely on bugs existing in the previous versions.
 If you want to upgrade to the next major version, please read release notes and migration guides to ensure a smooth transition.
 
-Starting with version 4, code-mods for upgrading to the next major version will be provided.
+Benchmarks comparing bundle size and runtime overhead against other CSS-in-JS libraries are available in [`tools/benchmarks/`](tools/benchmarks/README.md).
+Run `yarn workspace @mochi-css/benchmarks benchmark` from the repo root to reproduce results on your machine.
 
-Benchmarks and performance comparisons will be released at a later stage.
+### Latest benchmark results
+
+Fixture: mock Mochi homepage (Navbar, Hero, Stats, Features, CodeShowcase, ApiCarousel, ComponentExplorer, Cta, Footer).
+Measured on an Intel Core i7-14700K with Slow 4G throttling (1.6 Mbps, 150 ms RTT) and 8x CPU slowdown.
+
+| Library               | Build time | JS bundle (gz) | CSS output (gz) | FCP   |
+|-----------------------|------------|----------------|-----------------|-------|
+| `mochi-vanilla-react` | 1.6 s      | 61.4 kB        | 2.1 kB          | 1.9 s |
+| `mochi-stitches`      | 1.6 s      | 69.6 kB        | 1.8 kB          | 2.2 s |
+| `vanilla-extract`     | 2.3 s      | 60.9 kB        | 1.6 kB          | 1.9 s |
+| `stitches`            | 1.5 s      | 67.4 kB        | 0 kB *          | 2.0 s |
+| `panda`               | 2.4 s      | 72.0 kB        | 6.1 kB          | 2.3 s |
+| `tailwind`            | 1.6 s      | 60.6 kB        | 3.4 kB          | 1.9 s |
+
+* Stitches.js injects styles at runtime — no CSS file is produced.
 
 ---
 
@@ -91,20 +108,17 @@ Benchmarks and performance comparisons will be released at a later stage.
 
 | Feature                      | Status         | Notes                                                                                                                                                  |
 |------------------------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Zero runtime**             | ✅ Done        | Style object arguments are replaced with pre-computed values at build time, eliminating runtime overhead                                               |
-| **Benchmarks**               | ✅ Done        | Compare bundle/runtime size with other CSS-in-JS libraries                                                                                             |
 | **Mochi.css/mango**          | 🕒 Queued      | Theming library built on top of Mochi.css/vanilla                                                                                                      |
-| **Stitches.js adapter**      | ✅ Done        | Drop-in replacement for `css`, `styled`, `globalCss`, `keyframes`, and `createTheme` from Stitches.js that runs on Mochi.css                           |
 | **Partial PandaCSS adapter** | 🕒 Queued      | Drop-in replacement for `styled` and `cva` from PandaCSS. Other features may not be supported due to different architectures of PandaCSS and Mochi.css |
-| **Standalone css building**  | 🚧 In Progress | Extract and bundle static styles from a library                                                                                                        |
-| **CSS optimization**         | 🕒 Queued      | Perform simple optimizations on the generated code                                                                                                     |
-| **Mochi.css/bento**          | 🕒 Queued      | Layouting library providing primitives for shaping your ui                                                                                             |
+| **CSS optimization**         | 🚧 In Progress | Perform simple optimizations on the generated code                                                                                                     |
+| **Mochi.css/bento**          | 🚧 In Progress | Layouting library providing primitives for shaping your ui                                                                                             |
 | **Blog example app**         | 🕒 Queued      | My(Niikelion) personal blog built with Mochi.css provided as an example of a small, functional app                                                     |
 | **Japanese learning app**    | 🕒 Queued      | Example japanese learning website. Content will not be included in the source code                                                                     |
 
 Status legend
 
 🚧 In Progress – actively being worked on
+
 🕒 Queued – planned, not yet in development
 
 ---

--- a/packages/esbuild/README.md
+++ b/packages/esbuild/README.md
@@ -1,0 +1,99 @@
+# 🧁 Mochi-CSS/esbuild
+
+This package is part of the [Mochi-CSS project](https://github.com/Niikelion/mochi-css).
+It integrates compile-time CSS-in-JS into your esbuild builds.
+
+## Installation
+
+```bash
+npm i @mochi-css/vanilla @mochi-css/react
+npm i -D @mochi-css/esbuild
+```
+
+> `@mochi-css/builder` and `@mochi-css/config` install transitively and do not need to be listed explicitly.
+
+---
+
+## Setup
+
+### 1. `mochi.config.ts`
+
+Create a config file in your project root:
+
+```typescript
+// mochi.config.ts
+import { defineConfig } from "@mochi-css/config"
+
+export default defineConfig({
+    roots: ["src"],
+})
+```
+
+See [`@mochi-css/config`](../config/README.md) for the full list of shared options.
+
+### 2. Build script
+
+Add the plugin to your esbuild build script:
+
+```typescript
+// build.mjs
+import { build } from "esbuild"
+import { mochiCss } from "@mochi-css/esbuild"
+
+await build({
+    entryPoints: ["src/index.ts"],
+    outdir: "dist",
+    bundle: true,
+    plugins: [mochiCss()],
+})
+```
+
+The plugin reads all options from `mochi.config.ts` automatically.
+
+---
+
+## How It Works
+
+The plugin hooks into esbuild's lifecycle:
+
+1. **`onStart`** - loads `mochi.config.ts`, scans source files, extracts styles into an in-memory CSS manifest
+2. **`onResolve`** - intercepts synthetic `mochi-css-asset:` import IDs injected by the load hook
+3. **`onLoad` (source files)** - injects CSS import statements into files that have extracted styles
+4. **`onLoad` (virtual namespace)** - serves CSS content for virtual imports (virtual mode only)
+5. **`onEnd`** - writes CSS files to `outdir` (external mode only)
+
+---
+
+## CSS Output Modes
+
+### Virtual mode (default)
+
+CSS is served as virtual modules inside esbuild. When `bundle: true`, esbuild bundles the CSS into a companion `.css` file alongside the output JS.
+
+```typescript
+plugins: [mochiCss()]
+```
+
+Use this for app builds where esbuild is the final bundler.
+
+### External mode
+
+CSS imports are marked as external, so they survive in the output JS. CSS files are written flat into `outdir` in `onEnd`. Downstream bundlers (Vite, Next.js) then resolve and process the CSS automatically.
+
+```typescript
+plugins: [mochiCss({ externalCss: true })]
+```
+
+Use this when distributing a component library — consumers get zero-config CSS auto-import.
+
+---
+
+## Options
+
+| Option       | Type            | Default                              | Description |
+|--------------|-----------------|--------------------------------------|-------------|
+| `externalCss`| `boolean`       | `false`                              | Write CSS files to disk and mark imports as external (library distribution mode) |
+| `entries`    | `string[]`      | `build.initialOptions.entryPoints`   | Entry files where the global CSS import is injected |
+| `plugins`    | `MochiPlugin[]` | `[]`                                 | Additional Mochi plugins, merged with those from `mochi.config.ts` |
+
+> Prefer setting options in `mochi.config.ts` — inline options override the file config but are not shared with other integrations.

--- a/packages/esbuild/eslint.config.mts
+++ b/packages/esbuild/eslint.config.mts
@@ -1,0 +1,2 @@
+import { eslintConfig } from "@mochi-css/shared-config/eslint"
+export default eslintConfig

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@mochi-css/esbuild",
+    "repository": "git@github.com:Niikelion/mochi-css.git",
+    "version": "7.0.0",
+    "license": "MIT",
+    "main": "dist/index.js",
+    "module": "dist/index.mjs",
+    "types": "dist/index.d.ts",
+    "files": [
+        "/dist"
+    ],
+    "exports": {
+        "import": {
+            "types": "./dist/index.d.mts",
+            "import": "./dist/index.mjs"
+        },
+        "require": {
+            "types": "./dist/index.d.ts",
+            "require": "./dist/index.js"
+        }
+    },
+    "scripts": {
+        "build": "tsc --noEmit && tsdown",
+        "test": "vitest",
+        "coverage": "vitest run --coverage",
+        "lint": "eslint src",
+        "lint:fix": "eslint src --fix",
+        "format": "prettier --write ."
+    },
+    "devDependencies": {
+        "@mochi-css/shared-config": "^2.0.0",
+        "@mochi-css/test": "^2.0.0",
+        "@types/node": "^24.8.1",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.15"
+    },
+    "dependencies": {
+        "@mochi-css/builder": "^7.0.0",
+        "@mochi-css/config": "^7.0.0"
+    },
+    "peerDependencies": {
+        "esbuild": "^0.25"
+    }
+}

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -32,6 +32,7 @@
         "@mochi-css/test": "^2.0.0",
         "@types/node": "^24.8.1",
         "esbuild": "^0.25.0",
+        "eslint": "^9.39.2",
         "typescript": "^5.9.3",
         "vitest": "^4.0.15"
     },

--- a/packages/esbuild/src/index.spec.ts
+++ b/packages/esbuild/src/index.spec.ts
@@ -1,0 +1,451 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "path";
+
+const { mockTransform, mockLoadConfig, mockCollectMochiCss } = vi.hoisted(
+    () => ({
+        mockTransform: vi.fn(
+            async (source: string, _opts: { filePath: string }) => source,
+        ),
+        mockLoadConfig: vi.fn(async () => ({})),
+        mockCollectMochiCss: vi.fn(
+            async (): Promise<{
+                files?: Record<string, string>;
+                global?: string;
+                sourcemods?: Record<string, string>;
+            }> => ({ files: {}, global: undefined }),
+        ),
+    }),
+);
+
+vi.mock("@mochi-css/config", () => ({
+    loadConfig: mockLoadConfig,
+    resolveConfig: vi.fn(async (_file: unknown, _opts: unknown) => ({
+        plugins: [],
+        roots: ["src"],
+        splitCss: false,
+        onDiagnostic: undefined,
+    })),
+    FullContext: class {
+        filePreProcess = {
+            transform: (source: string, opts: { filePath: string }) =>
+                mockTransform(source, opts),
+        };
+        stages = { getAll: () => [] };
+        sourceTransforms = { getAll: () => [] };
+        postEvalTransforms = { getAll: () => [] };
+        emitHooks = { getAll: () => [] };
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        cleanup = { runAll: () => {} };
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        onDiagnostic = () => {};
+        initializeStages = { merged: () => undefined };
+        prepareAnalysis = { merged: () => undefined };
+        getFileData = { merged: () => undefined };
+        invalidateFiles = { merged: () => undefined };
+        resetCrossFileState = { merged: () => undefined };
+        getFilesToBundle = { merged: () => undefined };
+    },
+    createBuilder: vi.fn(() => ({
+        collectMochiCss: mockCollectMochiCss,
+    })),
+}));
+
+vi.mock("@mochi-css/builder", async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...(actual as object),
+        fileHash: (id: string) =>
+            id
+                .split("/")
+                .pop()
+                ?.replace(/\.[^.]+$/, "") ?? id,
+    };
+});
+
+vi.mock("fs/promises", () => ({
+    default: {
+        readFile: vi.fn(async () => "const x = 1"),
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        writeFile: vi.fn(async () => {}),
+        mkdir: vi.fn(async () => undefined),
+    },
+}));
+
+import { mochiCss } from "./index.js";
+import fsMock from "fs/promises";
+
+type LoadResult = { contents: string; loader: string } | null | undefined;
+type ResolveResult =
+    | { path: string; namespace?: string; external?: boolean }
+    | null
+    | undefined;
+type OnStartHandler = () => Promise<void>;
+type OnResolveHandler = (args: {
+    path: string;
+    importer: string;
+}) => ResolveResult;
+type OnLoadHandler = (args: {
+    path: string;
+    namespace?: string;
+}) => Promise<LoadResult> | LoadResult;
+type OnEndHandler = () => Promise<void>;
+
+interface MockBuild {
+    initialOptions: {
+        entryPoints?: string[];
+        outdir?: string;
+        outbase?: string;
+    };
+    onStartHandlers: OnStartHandler[];
+    onResolveHandlers: { filter: RegExp; fn: OnResolveHandler }[];
+    onLoadHandlers: { filter: RegExp; namespace?: string; fn: OnLoadHandler }[];
+    onEndHandlers: OnEndHandler[];
+    onStart(fn: OnStartHandler): void;
+    onResolve(opts: { filter: RegExp }, fn: OnResolveHandler): void;
+    onLoad(
+        opts: { filter: RegExp; namespace?: string },
+        fn: OnLoadHandler,
+    ): void;
+    onEnd(fn: OnEndHandler): void;
+    triggerStart(): Promise<void>;
+    triggerResolve(path: string, importer?: string): ResolveResult;
+    triggerLoad(filePath: string, namespace?: string): Promise<LoadResult>;
+    triggerEnd(): Promise<void>;
+}
+
+function createMockBuild(
+    opts: { entryPoints?: string[]; outdir?: string; outbase?: string } = {},
+): MockBuild {
+    const build: MockBuild = {
+        initialOptions: {
+            entryPoints: opts.entryPoints ?? [],
+            outdir: opts.outdir ?? "dist",
+            outbase: opts.outbase,
+        },
+        onStartHandlers: [],
+        onResolveHandlers: [],
+        onLoadHandlers: [],
+        onEndHandlers: [],
+        onStart(fn) {
+            this.onStartHandlers.push(fn);
+        },
+        onResolve(o, fn) {
+            this.onResolveHandlers.push({ filter: o.filter, fn });
+        },
+        onLoad(o, fn) {
+            this.onLoadHandlers.push({
+                filter: o.filter,
+                namespace: o.namespace,
+                fn,
+            });
+        },
+        onEnd(fn) {
+            this.onEndHandlers.push(fn);
+        },
+        async triggerStart() {
+            for (const fn of this.onStartHandlers) await fn();
+        },
+        triggerResolve(filePath, importer = "") {
+            for (const { filter, fn } of this.onResolveHandlers) {
+                if (filter.test(filePath)) {
+                    const result = fn({ path: filePath, importer });
+                    if (result) return result;
+                }
+            }
+            return undefined;
+        },
+        async triggerLoad(filePath, namespace) {
+            for (const { filter, namespace: ns, fn } of this.onLoadHandlers) {
+                const nsMatch =
+                    namespace !== undefined
+                        ? ns === namespace
+                        : ns === undefined;
+                if (filter.test(filePath) && nsMatch) {
+                    const result = await fn({ path: filePath, namespace });
+                    if (result !== undefined) return result;
+                }
+            }
+            return undefined;
+        },
+        async triggerEnd() {
+            for (const fn of this.onEndHandlers) await fn();
+        },
+    };
+    return build;
+}
+
+describe("mochiCss esbuild plugin — virtual mode", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockLoadConfig.mockResolvedValue({});
+        mockCollectMochiCss.mockResolvedValue({ files: {}, global: undefined });
+        mockTransform.mockImplementation(async (source: string) => source);
+        vi.mocked(fsMock.readFile).mockResolvedValue("const x = 1" as never);
+    });
+
+    it("registers onStart, onResolve, onLoad hooks", async () => {
+        const plugin = mochiCss();
+        const build = createMockBuild();
+        await plugin.setup(build as never);
+
+        expect(build.onStartHandlers).toHaveLength(1);
+        expect(build.onResolveHandlers.length).toBeGreaterThan(0);
+        expect(build.onLoadHandlers.length).toBeGreaterThan(0);
+    });
+
+    it("resolves mochi-css-asset: to mochi-css namespace", async () => {
+        const plugin = mochiCss();
+        const build = createMockBuild();
+        await plugin.setup(build as never);
+
+        const result = build.triggerResolve("mochi-css-asset:global");
+        expect(result).toBeDefined();
+        expect(result?.namespace).toBe("mochi-css");
+        expect(result?.path).toBe("global");
+    });
+
+    it("serves global CSS from namespace loader", async () => {
+        mockCollectMochiCss.mockResolvedValue({
+            global: ".g { color: red; }",
+            files: {},
+        });
+        const plugin = mochiCss();
+        const build = createMockBuild();
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        const result = await build.triggerLoad("global", "mochi-css");
+        expect(result?.contents).toBe(".g { color: red; }");
+        expect(result?.loader).toBe("css");
+    });
+
+    it("serves per-file CSS from namespace loader", async () => {
+        const srcPath = path.posix.resolve(
+            process.cwd().replaceAll("\\", "/"),
+            "src/Button.tsx",
+        );
+        mockCollectMochiCss.mockResolvedValue({
+            files: { [srcPath]: ".btn { color: blue; }" },
+            global: undefined,
+        });
+        const plugin = mochiCss();
+        const build = createMockBuild();
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        // fileHash mock returns basename without extension → "Button"
+        const result = await build.triggerLoad("Button", "mochi-css");
+        expect(result?.contents).toBe(".btn { color: blue; }");
+        expect(result?.loader).toBe("css");
+    });
+
+    it("returns empty string from namespace loader for unknown id", async () => {
+        const plugin = mochiCss();
+        const build = createMockBuild();
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        const result = await build.triggerLoad("unknown-hash", "mochi-css");
+        expect(result?.contents).toBe("");
+    });
+
+    it("injects global CSS import into entry files", async () => {
+        mockCollectMochiCss.mockResolvedValue({ global: ".g {}", files: {} });
+
+        const plugin = mochiCss({ entries: ["src/index.ts"] });
+        const build = createMockBuild({ entryPoints: ["src/index.ts"] });
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        const result = await build.triggerLoad(
+            path.resolve("src/index.ts").replaceAll("\\", "/"),
+        );
+        expect(result?.contents).toContain(`import "mochi-css-asset:global"`);
+        expect(result?.loader).toBe("ts");
+    });
+
+    it("injects per-file CSS import into file with CSS", async () => {
+        const srcPath = path.resolve("src/Button.tsx").replaceAll("\\", "/");
+        mockCollectMochiCss.mockResolvedValue({
+            files: { [srcPath]: ".btn {}" },
+            global: undefined,
+        });
+
+        const plugin = mochiCss();
+        const build = createMockBuild();
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        const result = await build.triggerLoad(
+            path.resolve("src/Button.tsx").replaceAll("\\", "/"),
+        );
+        expect(result?.contents).toContain(`import "mochi-css-asset:Button"`);
+    });
+
+    it("returns null for source files with no CSS and no sourcemods", async () => {
+        const plugin = mochiCss();
+        const build = createMockBuild();
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        const result = await build.triggerLoad(
+            path.resolve("src/Other.tsx").replaceAll("\\", "/"),
+        );
+        expect(result).toBeNull();
+    });
+
+    it("applies sourcemods to source files", async () => {
+        const srcPath = path.resolve("src/Widget.tsx").replaceAll("\\", "/");
+        mockCollectMochiCss.mockResolvedValue({
+            files: {},
+            global: undefined,
+            sourcemods: { [srcPath]: "const x = 'patched'" },
+        });
+
+        const plugin = mochiCss();
+        const build = createMockBuild();
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        const result = await build.triggerLoad(srcPath);
+        expect(result?.contents).toContain("const x = 'patched'");
+        expect(mockTransform).not.toHaveBeenCalled();
+    });
+
+    it("does not register onEnd in virtual mode", async () => {
+        const plugin = mochiCss();
+        const build = createMockBuild();
+        await plugin.setup(build as never);
+
+        expect(build.onEndHandlers).toHaveLength(0);
+    });
+});
+
+describe("mochiCss esbuild plugin — external mode", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockLoadConfig.mockResolvedValue({});
+        mockCollectMochiCss.mockResolvedValue({ files: {}, global: undefined });
+        mockTransform.mockImplementation(async (source: string) => source);
+        vi.mocked(fsMock.readFile).mockResolvedValue("const x = 1" as never);
+        vi.mocked(fsMock.writeFile).mockResolvedValue(undefined);
+        vi.mocked(fsMock.mkdir).mockResolvedValue(undefined as never);
+    });
+
+    it("resolves mochi-css-asset: as external with relative css path", async () => {
+        const entryFile = path.resolve("src/index.ts").replaceAll("\\", "/");
+
+        const plugin = mochiCss({ externalCss: true });
+        const build = createMockBuild({
+            entryPoints: [entryFile],
+            outdir: "dist",
+        });
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        const result = build.triggerResolve(
+            "mochi-css-asset:global",
+            entryFile,
+        );
+        expect(result?.external).toBe(true);
+        expect(result?.path).toMatch(/\.css$/);
+        // src/index.ts → dist/src/index.js; global.css is at dist/global.css → "../global.css"
+        expect(result?.path).toBe("../global.css");
+    });
+
+    it("writes CSS files to outdir in onEnd", async () => {
+        const srcPath = path.resolve("src/Button.tsx").replaceAll("\\", "/");
+        mockCollectMochiCss.mockResolvedValue({
+            files: { [srcPath]: ".btn { color: blue; }" },
+            global: ".g { margin: 0; }",
+        });
+
+        const plugin = mochiCss({ externalCss: true });
+        const build = createMockBuild({ outdir: "dist" });
+        await plugin.setup(build as never);
+        await build.triggerStart();
+        await build.triggerEnd();
+
+        expect(fsMock.writeFile).toHaveBeenCalledWith(
+            expect.stringContaining("Button.css"),
+            ".btn { color: blue; }",
+            "utf8",
+        );
+        expect(fsMock.writeFile).toHaveBeenCalledWith(
+            expect.stringContaining("global.css"),
+            ".g { margin: 0; }",
+            "utf8",
+        );
+    });
+
+    it("creates outdir before writing CSS files", async () => {
+        mockCollectMochiCss.mockResolvedValue({ global: ".g {}", files: {} });
+
+        const plugin = mochiCss({ externalCss: true });
+        const build = createMockBuild({ outdir: "dist" });
+        await plugin.setup(build as never);
+        await build.triggerStart();
+        await build.triggerEnd();
+
+        expect(fsMock.mkdir).toHaveBeenCalledWith(expect.any(String), {
+            recursive: true,
+        });
+    });
+
+    it("does not write CSS if no manifest", async () => {
+        const plugin = mochiCss({ externalCss: true });
+        const build = createMockBuild({ outdir: "dist" });
+        await plugin.setup(build as never);
+        // Do NOT trigger start — manifest remains undefined
+        await build.triggerEnd();
+
+        expect(fsMock.writeFile).not.toHaveBeenCalled();
+    });
+});
+
+describe("mochiCss esbuild plugin — entry detection", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockLoadConfig.mockResolvedValue({});
+        mockCollectMochiCss.mockResolvedValue({ global: ".g {}", files: {} });
+        mockTransform.mockImplementation(async (source: string) => source);
+        vi.mocked(fsMock.readFile).mockResolvedValue("const x = 1" as never);
+    });
+
+    it("auto-detects entries from string[] entryPoints", async () => {
+        const plugin = mochiCss();
+        const build = createMockBuild({
+            entryPoints: ["src/main.ts"],
+            outdir: "dist",
+        });
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        const result = await build.triggerLoad(
+            path.resolve("src/main.ts").replaceAll("\\", "/"),
+        );
+        expect(result?.contents).toContain(`import "mochi-css-asset:global"`);
+    });
+
+    it("opts.entries overrides auto-detection", async () => {
+        const plugin = mochiCss({ entries: ["src/custom.ts"] });
+        const build = createMockBuild({
+            entryPoints: ["src/main.ts"],
+            outdir: "dist",
+        });
+        await plugin.setup(build as never);
+        await build.triggerStart();
+
+        // src/main.ts should NOT get the import
+        const main = await build.triggerLoad(
+            path.resolve("src/main.ts").replaceAll("\\", "/"),
+        );
+        expect(main).toBeNull();
+
+        // src/custom.ts SHOULD get the import
+        const custom = await build.triggerLoad(
+            path.resolve("src/custom.ts").replaceAll("\\", "/"),
+        );
+        expect(custom?.contents).toContain(`import "mochi-css-asset:global"`);
+    });
+});

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -1,0 +1,263 @@
+import type { Plugin, BuildOptions } from "esbuild";
+import fs from "fs/promises";
+import { fileHash, path } from "@mochi-css/builder";
+import {
+    loadConfig,
+    resolveConfig,
+    FullContext,
+    createBuilder,
+    type Config,
+} from "@mochi-css/config";
+import { diagnosticToString, type OnDiagnostic } from "@mochi-css/core";
+
+const ASSET_PREFIX = "mochi-css-asset:";
+const MOCHI_CSS_NAMESPACE = "mochi-css";
+
+/**
+ * Inline options for the Mochi CSS esbuild plugin.
+ *
+ * Most options are loaded automatically from `mochi.config.ts`.
+ * Inline options passed here are merged on top of the file config.
+ *
+ * @example
+ * ```ts
+ * // build.mjs
+ * import { build } from "esbuild"
+ * import { mochiCss } from "@mochi-css/esbuild"
+ *
+ * await build({
+ *     entryPoints: ["src/index.ts"],
+ *     outdir: "dist",
+ *     bundle: true,
+ *     plugins: [mochiCss()],
+ * })
+ * ```
+ *
+ * For library distribution where Vite/Next.js consumers should auto-import CSS:
+ * ```ts
+ * plugins: [mochiCss({ externalCss: true })]
+ * ```
+ */
+export type MochiEsbuildOptions = Partial<
+    Pick<Config, "plugins"> & {
+        /**
+         * Entry files where the global CSS import is injected.
+         * Defaults to `build.initialOptions.entryPoints` (normalized).
+         */
+        entries?: string[];
+        /**
+         * When `true`, CSS imports are marked external so they survive in the
+         * output JS. Downstream bundlers (Vite, Next.js) then resolve and process
+         * them automatically. CSS files are written to `outdir` in `onEnd`.
+         *
+         * Use this when distributing a component library.
+         * Default: `false` (virtual CSS modules bundled by esbuild).
+         */
+        externalCss?: boolean;
+    }
+>;
+
+function normalizeEntryPoints(ep: BuildOptions["entryPoints"]): Set<string> {
+    if (!ep) return new Set();
+    if (Array.isArray(ep)) {
+        return new Set(
+            ep.map((e) =>
+                path.fromSystemPath(
+                    path.resolve(typeof e === "string" ? e : e.in),
+                ),
+            ),
+        );
+    }
+    return new Set(
+        Object.values(ep).map((e) => path.fromSystemPath(path.resolve(e))),
+    );
+}
+
+function sourceToOutputPath(
+    srcPath: string,
+    outdir: string,
+    outbase: string,
+): string {
+    const rel = path.relative(outbase, srcPath);
+    return path.join(outdir, rel).replace(/\.(ts|tsx)$/, ".js");
+}
+
+/**
+ * Esbuild plugin that statically extracts Mochi CSS styles from TypeScript/TSX source
+ * files. Supports both virtual CSS modules (app builds) and external CSS files
+ * (library distribution).
+ */
+export function mochiCss(opts?: MochiEsbuildOptions): Plugin {
+    let resolved: Config | undefined;
+    let context: FullContext | undefined;
+    let builder: ReturnType<typeof createBuilder> | undefined;
+    let manifest:
+        | {
+              global?: string;
+              files?: Record<string, string>;
+              sourcemods?: Record<string, string>;
+          }
+        | undefined;
+    const cssMap = new Map<string, string>();
+
+    return {
+        name: "mochi-css",
+        setup(build) {
+            const externalCss = opts?.externalCss ?? false;
+            const outdir = path.fromSystemPath(
+                build.initialOptions.outdir ?? "dist",
+            );
+            const outbase = path.fromSystemPath(
+                build.initialOptions.outbase ??
+                    path.resolve(path.fromSystemPath(process.cwd())),
+            );
+
+            const entries: Set<string> = opts?.entries
+                ? new Set(
+                      opts.entries.map((e) =>
+                          path.fromSystemPath(path.resolve(e)),
+                      ),
+                  )
+                : normalizeEntryPoints(build.initialOptions.entryPoints);
+
+            build.onStart(async () => {
+                cssMap.clear();
+
+                if (!builder) {
+                    const cwd = path.toSystemPath(
+                        path.fromSystemPath(process.cwd()),
+                    );
+                    const fileConfig = await loadConfig(cwd);
+                    resolved = await resolveConfig(fileConfig, opts);
+
+                    const defaultDiagnostic: OnDiagnostic = (event) => {
+                        const content = diagnosticToString(event);
+                        if (event.severity === "debug" && !resolved?.debug)
+                            return;
+
+                        console.log(content);
+                    };
+
+                    const onDiagnostic =
+                        resolved.onDiagnostic ?? defaultDiagnostic;
+                    const ctx = new FullContext(onDiagnostic);
+                    context = ctx;
+                    for (const plugin of resolved.plugins) {
+                        plugin.onLoad?.(ctx);
+                    }
+                    builder = createBuilder(resolved, ctx);
+                }
+
+                const result = await builder.collectMochiCss();
+                manifest = result;
+
+                if (result.global) cssMap.set("global", result.global);
+                for (const [srcPath, css] of Object.entries(
+                    result.files ?? {},
+                )) {
+                    cssMap.set(fileHash(srcPath), css);
+                }
+            });
+
+            build.onResolve({ filter: /^mochi-css-asset:/ }, (args) => {
+                const id = args.path.slice(ASSET_PREFIX.length);
+
+                if (externalCss) {
+                    const srcPath = path.fromSystemPath(args.importer);
+                    const outPath = sourceToOutputPath(
+                        srcPath,
+                        outdir,
+                        outbase,
+                    );
+                    const cssFile =
+                        id === "global" ? "global.css" : `${id}.css`;
+                    const cssAbsPath = path.join(outdir, cssFile);
+                    const rel = path.relative(
+                        path.dirname(outPath),
+                        cssAbsPath,
+                    );
+                    const relPath = rel.startsWith(".") ? rel : "./" + rel;
+                    return { path: relPath, external: true };
+                }
+
+                return { path: id, namespace: MOCHI_CSS_NAMESPACE };
+            });
+
+            build.onLoad(
+                { filter: /.*/, namespace: MOCHI_CSS_NAMESPACE },
+                (args) => ({
+                    contents: cssMap.get(args.path) ?? "",
+                    loader: "css",
+                }),
+            );
+
+            build.onLoad({ filter: /\.(ts|tsx|js|jsx)$/ }, async (args) => {
+                if (!manifest || !context) return null;
+
+                const filePath = path.fromSystemPath(args.path);
+                const source = await fs.readFile(args.path, "utf8");
+                const transformed =
+                    manifest.sourcemods?.[filePath] ??
+                    (await context.filePreProcess.transform(source, {
+                        filePath,
+                    }));
+
+                const imports: string[] = [];
+                if (entries.has(filePath) && manifest.global) {
+                    imports.push(`import "${ASSET_PREFIX}global";`);
+                }
+                if (manifest.files?.[filePath]) {
+                    imports.push(
+                        `import "${ASSET_PREFIX}${fileHash(filePath)}";`,
+                    );
+                }
+
+                if (imports.length === 0 && transformed === source) return null;
+
+                const ext = path.extname(args.path).slice(1) as
+                    | "ts"
+                    | "tsx"
+                    | "js"
+                    | "jsx";
+                return {
+                    contents: imports.join("\n") + "\n" + transformed,
+                    loader: ext,
+                };
+            });
+
+            if (externalCss) {
+                build.onEnd(async () => {
+                    if (!manifest) return;
+                    try {
+                        await fs.mkdir(path.toSystemPath(outdir), {
+                            recursive: true,
+                        });
+                        for (const [srcPath, css] of Object.entries(
+                            manifest.files ?? {},
+                        )) {
+                            const hash = fileHash(srcPath);
+                            await fs.writeFile(
+                                path.toSystemPath(
+                                    path.join(outdir, `${hash}.css`),
+                                ),
+                                css,
+                                "utf8",
+                            );
+                        }
+                        if (manifest.global) {
+                            await fs.writeFile(
+                                path.toSystemPath(
+                                    path.join(outdir, "global.css"),
+                                ),
+                                manifest.global,
+                                "utf8",
+                            );
+                        }
+                    } catch {
+                        // outdir creation or write failure — non-fatal
+                    }
+                });
+            }
+        },
+    };
+}

--- a/packages/esbuild/tsconfig.json
+++ b/packages/esbuild/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@gamedev-sensei/ts-config/tsconfig.json"
+}

--- a/packages/esbuild/tsdown.config.mts
+++ b/packages/esbuild/tsdown.config.mts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig([
+    {
+        entry: ["src/index.ts"],
+        format: ["esm", "cjs"],
+        dts: true,
+        sourcemap: true,
+        clean: true,
+        skipNodeModulesBundle: true,
+        external: (id: string) => id.startsWith("@mochi-css/"),
+    },
+    { attw: true },
+])

--- a/packages/esbuild/vitest.config.ts
+++ b/packages/esbuild/vitest.config.ts
@@ -1,0 +1,2 @@
+import { vitestConfig } from "@mochi-css/test/vitest"
+export default vitestConfig

--- a/packages/tsuki/README.md
+++ b/packages/tsuki/README.md
@@ -9,7 +9,7 @@ You can run it with:
 npx @mochi-css/tsuki
 ```
 
-`tsuki` handles installing integrations for next.js and vite frameworks.
+`tsuki` handles installing integrations for vite, next.js, and esbuild.
 To get more info, run it with `-h` or `--help` option.
 
 ## What `tsuki` sets up
@@ -24,6 +24,15 @@ Use the `--preset` / `-p` flag to choose a framework preset non-interactively:
 ```bash
 npx @mochi-css/tsuki --preset vite
 npx @mochi-css/tsuki --preset nextjs
+npx @mochi-css/tsuki --preset esbuild
+npx @mochi-css/tsuki --preset lib
 ```
 
 If `-p` is omitted, `tsuki` will prompt you to select a preset interactively.
+
+| Preset    | Description |
+|-----------|-------------|
+| `vite`    | Vite app — adds `mochiCss()` to `vite.config.ts` |
+| `nextjs`  | Next.js app — wraps `next.config.ts` with `withMochi()` |
+| `esbuild` | Standalone esbuild build — creates or patches a `build.mjs` script |
+| `lib`     | Framework-agnostic library — sets up `mochi.config.ts` and PostCSS only |

--- a/packages/tsuki/fixtures/esbuild-css/package.json
+++ b/packages/tsuki/fixtures/esbuild-css/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-esbuild-lib",
+    "version": "0.0.0",
+    "private": true,
+    "packageManager": "npm@10.9.2",
+    "type": "module"
+}

--- a/packages/tsuki/fixtures/esbuild-css/src/index.ts
+++ b/packages/tsuki/fixtures/esbuild-css/src/index.ts
@@ -1,0 +1,3 @@
+import { css } from "@mochi-css/vanilla"
+
+export const button = css({ color: "red", fontSize: 16 })

--- a/packages/tsuki/fixtures/esbuild-overlay/package.json
+++ b/packages/tsuki/fixtures/esbuild-overlay/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "my-esbuild-app",
+    "private": true,
+    "packageManager": "npm@10.9.2",
+    "type": "module",
+    "scripts": {
+        "build": "node build.mjs"
+    },
+    "devDependencies": {
+        "@mochi-css/esbuild": "file:__MOCHI_ROOT__/packages/esbuild",
+        "@mochi-css/vanilla": "file:__MOCHI_ROOT__/packages/vanilla",
+        "esbuild": "^0.25.0",
+        "typescript": "^5"
+    },
+    "overrides": {
+        "@mochi-css/builder": "file:__MOCHI_ROOT__/packages/builder",
+        "@mochi-css/config": "file:__MOCHI_ROOT__/packages/config",
+        "@mochi-css/core": "file:__MOCHI_ROOT__/packages/core",
+        "@mochi-css/plugins": "file:__MOCHI_ROOT__/packages/plugins",
+        "@mochi-css/vanilla": "file:__MOCHI_ROOT__/packages/vanilla"
+    }
+}

--- a/packages/tsuki/fixtures/esbuild-single-overlay/build.mjs
+++ b/packages/tsuki/fixtures/esbuild-single-overlay/build.mjs
@@ -1,0 +1,9 @@
+import { build } from "esbuild"
+import { mochiCss } from "@mochi-css/esbuild"
+
+await build({
+    entryPoints: ["src/index.ts"],
+    outdir: "dist",
+    bundle: true,
+    plugins: [mochiCss({ externalCss: true })],
+})

--- a/packages/tsuki/fixtures/esbuild-single-overlay/package.json
+++ b/packages/tsuki/fixtures/esbuild-single-overlay/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "my-esbuild-lib",
+    "private": true,
+    "packageManager": "npm@10.9.2",
+    "type": "module",
+    "scripts": {
+        "build": "node build.mjs"
+    },
+    "devDependencies": {
+        "@mochi-css/esbuild": "file:__MOCHI_ROOT__/packages/esbuild",
+        "@mochi-css/vanilla": "file:__MOCHI_ROOT__/packages/vanilla",
+        "esbuild": "^0.25.0",
+        "typescript": "^5"
+    },
+    "overrides": {
+        "@mochi-css/builder": "file:__MOCHI_ROOT__/packages/builder",
+        "@mochi-css/config": "file:__MOCHI_ROOT__/packages/config",
+        "@mochi-css/core": "file:__MOCHI_ROOT__/packages/core",
+        "@mochi-css/plugins": "file:__MOCHI_ROOT__/packages/plugins",
+        "@mochi-css/vanilla": "file:__MOCHI_ROOT__/packages/vanilla"
+    }
+}

--- a/packages/tsuki/fixtures/esbuild-split-overlay/build.mjs
+++ b/packages/tsuki/fixtures/esbuild-split-overlay/build.mjs
@@ -1,0 +1,9 @@
+import { build } from "esbuild"
+import { mochiCss } from "@mochi-css/esbuild"
+
+await build({
+    entryPoints: ["src/index.ts"],
+    outdir: "dist",
+    bundle: true,
+    plugins: [mochiCss({ externalCss: true })],
+})

--- a/packages/tsuki/fixtures/esbuild-split-overlay/mochi.config.ts
+++ b/packages/tsuki/fixtures/esbuild-split-overlay/mochi.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "@mochi-css/vanilla/config"
+
+export default defineConfig({
+    roots: ["src"],
+    tmpDir: ".mochi",
+    splitCss: true,
+})

--- a/packages/tsuki/fixtures/esbuild-split-overlay/package.json
+++ b/packages/tsuki/fixtures/esbuild-split-overlay/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "my-esbuild-lib",
+    "private": true,
+    "packageManager": "npm@10.9.2",
+    "type": "module",
+    "scripts": {
+        "build": "node build.mjs"
+    },
+    "devDependencies": {
+        "@mochi-css/esbuild": "file:__MOCHI_ROOT__/packages/esbuild",
+        "@mochi-css/vanilla": "file:__MOCHI_ROOT__/packages/vanilla",
+        "esbuild": "^0.25.0",
+        "typescript": "^5"
+    },
+    "overrides": {
+        "@mochi-css/builder": "file:__MOCHI_ROOT__/packages/builder",
+        "@mochi-css/config": "file:__MOCHI_ROOT__/packages/config",
+        "@mochi-css/core": "file:__MOCHI_ROOT__/packages/core",
+        "@mochi-css/plugins": "file:__MOCHI_ROOT__/packages/plugins",
+        "@mochi-css/vanilla": "file:__MOCHI_ROOT__/packages/vanilla"
+    }
+}

--- a/packages/tsuki/fixtures/esbuild/package.json
+++ b/packages/tsuki/fixtures/esbuild/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "my-esbuild-app",
+    "version": "0.0.0",
+    "private": true,
+    "packageManager": "npm@10.9.2",
+    "type": "module"
+}

--- a/packages/tsuki/fixtures/esbuild/src/index.ts
+++ b/packages/tsuki/fixtures/esbuild/src/index.ts
@@ -1,0 +1,1 @@
+export const greet = (name: string): string => `Hello, ${name}!`

--- a/packages/tsuki/src/index.ts
+++ b/packages/tsuki/src/index.ts
@@ -14,6 +14,7 @@ interface CliOptions {
     postcss?: string | true
     vite?: string | true
     next?: string | true
+    esbuild?: string | true
     framework?: string
 }
 
@@ -21,12 +22,13 @@ program
     .name("tsuki")
     .description("Add mochi-css to your project")
     .version(__VERSION__)
-    .addOption(new Option("-p, --preset <preset>", "Preset to use").choices(["vite", "nextjs", "lib"]))
+    .addOption(new Option("-p, --preset <preset>", "Preset to use").choices(["vite", "nextjs", "lib", "esbuild"]))
     .option("-n, --no-interactive", "Non-interactive mode: skip all prompts (treat as cancelled)")
     .option("--install", "Auto-accept package installation without prompting")
     .option("--postcss [path]", "Enable PostCSS module; optionally specify config path")
     .option("--vite [path]", "Use the given Vite config path instead of prompting")
     .option("--next [path]", "Use the given Next.js config path instead of prompting")
+    .option("--esbuild [path]", "Use the given esbuild build script path instead of prompting")
     .addOption(new Option("--framework <framework>", "UI framework to install support for").choices(["react"]))
     .action(async (options: CliOptions) => {
         p.intro(pc.cyan("Installing Mochi-CSS..."))
@@ -67,6 +69,7 @@ program
             else if (presetId === "nextjs") moduleOptions.postcss = true
             if (options.vite !== undefined) moduleOptions.vite = options.vite
             if (options.next !== undefined) moduleOptions.next = options.next
+            if (options.esbuild !== undefined) moduleOptions.esbuild = options.esbuild
             if (options.framework !== undefined) moduleOptions.framework = options.framework
 
             await runner.run({

--- a/packages/tsuki/src/modules/esbuild.ts
+++ b/packages/tsuki/src/modules/esbuild.ts
@@ -1,0 +1,135 @@
+import fsExtra from "fs-extra"
+import fs from "fs/promises"
+import * as p from "@clack/prompts"
+import { parseModule, generateCode } from "magicast"
+import type { Module, ModuleContext } from "@/types"
+import { mochiPackage } from "@/version"
+import { getPluginsElements, type ObjNode } from "./ast"
+import dedent from "dedent"
+
+const esbuildScriptNames = [
+    "build.mjs",
+    "build.ts",
+    "build.js",
+    "scripts/build.mjs",
+    "scripts/build.ts",
+    "scripts/build.js",
+    "esbuild.config.mjs",
+    "esbuild.config.ts",
+    "esbuild.config.js",
+]
+
+export function findEsbuildScript(): string | undefined {
+    return esbuildScriptNames.find((name) => fsExtra.existsSync(name))
+}
+
+// noinspection TypeScriptCheckImport
+const defaultEsbuildScript = /* language=typescript */ dedent`
+    import { build } from "esbuild"
+    import { mochiCss } from "@mochi-css/esbuild"
+
+    await build({
+        entryPoints: ["src/index.ts"],
+        outdir: "dist",
+        bundle: true,
+        plugins: [mochiCss()],
+    })
+`
+
+function addPluginCallToObj(obj: ObjNode, scriptPath: string): void {
+    const elements = getPluginsElements(obj, scriptPath)
+    elements.push({
+        type: "CallExpression",
+        callee: { type: "Identifier", name: "mochiCss" },
+        arguments: [],
+    })
+}
+
+function addMochiToEsbuildScript(mod: ReturnType<typeof parseModule>, scriptPath: string): void {
+    type DeclNode = { id: { type: string; name: string }; init: Record<string, unknown> | null }
+    type VarDeclNode = { type: "VariableDeclaration"; declarations: DeclNode[] }
+    type ExprStmt = { type: "ExpressionStatement"; expression: Record<string, unknown> }
+
+    const body = (mod.$ast as unknown as { body: unknown[] }).body
+
+    // Look for a call expression statement: `build({ ... })` or `await build({ ... })`
+    for (const stmt of body) {
+        const stmtTyped = stmt as Record<string, unknown>
+        if (stmtTyped["type"] !== "ExpressionStatement") continue
+
+        let callExpr = (stmtTyped as ExprStmt).expression
+        // Unwrap `await`
+        if (callExpr["type"] === "AwaitExpression") {
+            callExpr = callExpr["argument"] as Record<string, unknown>
+        }
+        if (callExpr["type"] !== "CallExpression") continue
+
+        const args = callExpr["arguments"] as Record<string, unknown>[]
+        const firstArg = args[0]
+        if (firstArg?.["type"] === "ObjectExpression") {
+            addPluginCallToObj(firstArg as ObjNode, scriptPath)
+            return
+        }
+    }
+
+    // Fallback: look for a variable holding the options object
+    for (const stmt of body) {
+        if ((stmt as { type: string }).type !== "VariableDeclaration") continue
+        for (const d of (stmt as VarDeclNode).declarations) {
+            if (d.init?.["type"] === "ObjectExpression") {
+                addPluginCallToObj(d.init as ObjNode, scriptPath)
+                return
+            }
+        }
+    }
+
+    throw new Error(`Failed to add mochiCss() plugin to ${scriptPath}`)
+}
+
+async function addMochiToScript(scriptPath: string): Promise<void> {
+    const content = await fs.readFile(scriptPath, "utf-8")
+    const mod = parseModule(content)
+
+    mod.imports.$prepend({ from: "@mochi-css/esbuild", imported: "mochiCss", local: "mochiCss" })
+    addMochiToEsbuildScript(mod, scriptPath)
+
+    const { code } = generateCode(mod)
+    await fs.writeFile(scriptPath, code)
+}
+
+export const esbuildModule: Module = {
+    id: "esbuild",
+    name: "esbuild",
+
+    async run(ctx: ModuleContext): Promise<void> {
+        const existingScript = findEsbuildScript()
+        const { esbuild: cliOption } = ctx.moduleOptions
+
+        let scriptPath: string
+        if (cliOption !== undefined) {
+            scriptPath = typeof cliOption === "string" ? cliOption : (existingScript ?? "build.mjs")
+        } else if (existingScript) {
+            scriptPath = existingScript
+        } else if (ctx.nonInteractive) {
+            scriptPath = "build.mjs"
+        } else {
+            const selected = await p.text({
+                message: "Path to esbuild build script",
+                placeholder: "build.mjs",
+                defaultValue: "build.mjs",
+            })
+            if (p.isCancel(selected)) return
+            scriptPath = selected
+        }
+
+        if (!fsExtra.existsSync(scriptPath)) {
+            await fs.writeFile(scriptPath, defaultEsbuildScript)
+            p.log.success("Created esbuild build script with mochi plugin")
+        } else {
+            await addMochiToScript(scriptPath)
+            p.log.success("Added mochiCss() to esbuild build script")
+        }
+
+        ctx.requirePackage(mochiPackage("@mochi-css/esbuild"))
+    },
+}

--- a/packages/tsuki/src/modules/index.ts
+++ b/packages/tsuki/src/modules/index.ts
@@ -1,6 +1,7 @@
 export { postcssModule, createPostcssModule } from "./postcss"
 export { viteModule } from "./vite"
 export { nextModule } from "./next"
+export { esbuildModule } from "./esbuild"
 export { createMochiConfigModule, findMochiConfig } from "./mochiConfig"
 export { createUiFrameworkModule } from "./uiFramework"
 export { createGitignoreModule } from "./gitignore"

--- a/packages/tsuki/src/presets/esbuild.ts
+++ b/packages/tsuki/src/presets/esbuild.ts
@@ -1,0 +1,18 @@
+import { createPostcssModule } from "@/modules/postcss"
+import { esbuildModule } from "@/modules/esbuild"
+import { createMochiConfigModule } from "@/modules/mochiConfig"
+import { createUiFrameworkModule } from "@/modules/uiFramework"
+import { createGitignoreModule } from "@/modules/gitignore"
+import type { Preset } from "@/types"
+
+export const esbuildPreset: Preset = {
+    id: "esbuild",
+    name: "esbuild",
+    setup(runner) {
+        runner.register(createMochiConfigModule({ tmpDir: ".mochi", roots: ["src"] }))
+        runner.register(createPostcssModule())
+        runner.register(esbuildModule)
+        runner.register(createUiFrameworkModule())
+        runner.register(createGitignoreModule(".mochi"))
+    },
+}

--- a/packages/tsuki/src/presets/index.ts
+++ b/packages/tsuki/src/presets/index.ts
@@ -1,12 +1,14 @@
 import { libPreset } from "./lib"
 import { vitePreset } from "./vite"
 import { nextjsPreset } from "./nextjs"
+import { esbuildPreset } from "./esbuild"
 import type { Preset } from "@/types"
 
-export { libPreset, vitePreset, nextjsPreset }
+export { libPreset, vitePreset, nextjsPreset, esbuildPreset }
 
 export const presets: Record<string, Preset> = {
     lib: libPreset,
     vite: vitePreset,
     nextjs: nextjsPreset,
+    esbuild: esbuildPreset,
 }

--- a/packages/tsuki/src/types.ts
+++ b/packages/tsuki/src/types.ts
@@ -11,6 +11,7 @@ export interface ModuleOptions {
     postcss?: string | true
     vite?: string | true
     next?: string | true
+    esbuild?: string | true
     framework?: string
 }
 

--- a/packages/tsuki/test/preset.test.ts
+++ b/packages/tsuki/test/preset.test.ts
@@ -20,7 +20,7 @@ vi.mock("../src/install", () => ({
 import * as p from "@clack/prompts"
 import { installPackages } from "@/install"
 import { ModuleRunner } from "@/runner"
-import { vitePreset, nextjsPreset } from "@/presets"
+import { vitePreset, nextjsPreset, esbuildPreset } from "@/presets"
 
 let tmpDir: string
 let origCwd: string
@@ -59,6 +59,41 @@ describe("vite preset integration", () => {
 
         const viteContent = await fs.readFile(path.join(tmpDir, "vite.config.ts"), "utf-8")
         expect(viteContent).toContain("mochiCss()")
+
+        expect(installPackages).toHaveBeenCalled()
+    })
+})
+
+describe("esbuild preset integration", () => {
+    it("creates default build.mjs and mochi config when neither exists", async () => {
+        const runner = new ModuleRunner()
+        esbuildPreset.setup(runner)
+        await runner.run({ moduleOptions: { esbuild: true } })
+
+        const buildContent = await fs.readFile(path.join(tmpDir, "build.mjs"), "utf-8")
+        expect(buildContent).toContain("mochiCss()")
+        expect(buildContent).toContain("@mochi-css/esbuild")
+
+        const mochiContent = await fs.readFile(path.join(tmpDir, "mochi.config.ts"), "utf-8")
+        expect(mochiContent).toContain("tmpDir")
+        expect(mochiContent).toContain(".mochi")
+
+        expect(installPackages).toHaveBeenCalled()
+    })
+
+    it("patches existing build.mjs to add mochiCss()", async () => {
+        await fs.writeFile(
+            path.join(tmpDir, "build.mjs"),
+            `import { build } from "esbuild"\nawait build({ entryPoints: ["src/index.ts"], outdir: "dist", bundle: true, plugins: [] })\n`,
+        )
+
+        const runner = new ModuleRunner()
+        esbuildPreset.setup(runner)
+        await runner.run({ moduleOptions: { esbuild: true } })
+
+        const buildContent = await fs.readFile(path.join(tmpDir, "build.mjs"), "utf-8")
+        expect(buildContent).toContain("mochiCss()")
+        expect(buildContent).toContain("@mochi-css/esbuild")
 
         expect(installPackages).toHaveBeenCalled()
     })

--- a/packages/tsuki/test/smoke.test.ts
+++ b/packages/tsuki/test/smoke.test.ts
@@ -143,6 +143,58 @@ describe("smoke", () => {
     )
 
     it(
+        "esbuild fixture (esbuild preset)",
+        async () => {
+            await copyFixture("esbuild", tmpDir)
+            await runTsuki(tmpDir, ["--no-interactive", "--preset", "esbuild"])
+
+            const build = await fs.readFile(path.join(tmpDir, "build.mjs"), "utf-8")
+            expect(build).toContain("mochiCss()")
+            expect(build).toContain("@mochi-css/esbuild")
+
+            const mochi = await fs.readFile(path.join(tmpDir, "mochi.config.ts"), "utf-8")
+            expect(mochi).toContain(".mochi")
+
+            await applyOverlay("esbuild", tmpDir)
+            await runCommand("npm", ["install"], tmpDir)
+            await runCommand("npm", ["run", "build"], tmpDir)
+        },
+        BUILD_TIMEOUT,
+    )
+
+    it(
+        "esbuild-css fixture — single combined CSS file (splitCss: false)",
+        async () => {
+            await copyFixture("esbuild-css", tmpDir)
+            await runTsuki(tmpDir, ["--no-interactive", "--preset", "esbuild"])
+            await applyOverlay("esbuild-single", tmpDir)
+            await runCommand("npm", ["install"], tmpDir)
+            await runCommand("npm", ["run", "build"], tmpDir)
+
+            const distFiles = await fs.readdir(path.join(tmpDir, "dist"))
+            expect(distFiles).toContain("global.css")
+            expect(distFiles.filter((f) => f.endsWith(".css") && f !== "global.css")).toHaveLength(0)
+        },
+        BUILD_TIMEOUT,
+    )
+
+    it(
+        "esbuild-css fixture — split CSS per file (splitCss: true)",
+        async () => {
+            await copyFixture("esbuild-css", tmpDir)
+            await runTsuki(tmpDir, ["--no-interactive", "--preset", "esbuild"])
+            await applyOverlay("esbuild-split", tmpDir)
+            await runCommand("npm", ["install"], tmpDir)
+            await runCommand("npm", ["run", "build"], tmpDir)
+
+            const distFiles = await fs.readdir(path.join(tmpDir, "dist"))
+            expect(distFiles).not.toContain("global.css")
+            expect(distFiles.some((f) => f.endsWith(".css"))).toBe(true)
+        },
+        BUILD_TIMEOUT,
+    )
+
+    it(
         "wrapped fixture (lib preset)",
         async () => {
             await copyFixture("wrapped", tmpDir)

--- a/tools/benchmarks/README.md
+++ b/tools/benchmarks/README.md
@@ -1,0 +1,105 @@
+# @mochi-css/benchmarks
+
+Benchmarks comparing build time, bundle size, and runtime performance of popular CSS-in-JS libraries against Mochi.css.
+
+## Libraries compared
+
+| Library               | Description                                                    |
+|-----------------------|----------------------------------------------------------------|
+| `mochi-vanilla-react` | Mochi.css with `@mochi-css/vanilla-react`                      |
+| `mochi-stitches`      | Mochi.css with the Stitches.js adapter (`@mochi-css/stitches`) |
+| `stitches`            | `@stitches/react` (runtime CSS-in-JS)                          |
+| `vanilla-extract`     | `@vanilla-extract/css` (build-time CSS-in-JS)                  |
+| `panda`               | PandaCSS                                                       |
+| `css-modules`         | Plain CSS Modules                                              |
+
+## Fixture
+
+A mock Mochi homepage with nine sections: Navbar, Hero, Stats, Features, CodeShowcase, ApiCarousel, ComponentExplorer, Cta, and Footer.
+Each section is styled using the library under test.
+The fixture is generated via codegen so all implementations are structurally equivalent.
+
+## Metrics
+
+| Metric         | Description                                                                                                                      |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------|
+| **Build time** | Cold build with `dist/` cleared. Libraries that require a codegen pre-step (Stitches, vanilla-extract, Panda) include that time. |
+| **JS bundle**  | Gzipped sum of all `.js` files in `dist/assets/`. Represents CSS-in-JS runtime overhead shipped to the browser.                  |
+| **CSS output** | Gzipped sum of all `.css` files in `dist/assets/`. Stitches injects styles at runtime so its CSS output is 0.                    |
+| **FCP**        | First Contentful Paint — time until the browser renders first text or image.                                                     |
+| **TBT**        | Total Blocking Time — sum of main-thread blocking time between FCP and TTI.                                                      |
+| **CLS**        | Cumulative Layout Shift.                                                                                                         |
+
+All browser metrics are measured with Playwright (Chromium headless) using CDP throttling: Slow 4G (~1.6 Mbps, 150 ms RTT) + 8x CPU slowdown applied to localhost.
+
+## How implementations are generated
+
+`mochi-vanilla-react` is the canonical, handwritten source implementation.
+All other implementations are derived from it automatically so that every library renders structurally identical output.
+
+### Codegen
+
+`codegen/index.ts` reads the `mochi-vanilla-react/src/` tree using SWC and produces a target-specific source tree for each library:
+
+- **Shared layout files** (`App.tsx`, section `.tsx` files, `tokens.ts`, `main.tsx`) are copied verbatim — the JSX structure and token values are identical across all implementations.
+- **Style files** (`.styled.ts` files and component `.tsx` files) are parsed with SWC to extract `styled()` and `css()` calls including their full style objects.
+  The extracted style data is then handed to a per-library generator that re-emits equivalent code using that library's API.
+
+Each library has its own generator in `codegen/generators/`.
+The generators translate the Mochi style objects into the target library's syntax (e.g., vanilla-extract's `style()`, Panda's `css()`, Stitches' `styled()`),
+preserving property values, local CSS variables, token references, and animation imports.
+
+To regenerate a specific implementation:
+
+```bash
+yarn workspace @mochi-css/benchmarks codegen  # regenerates all
+```
+
+Or for a single target:
+
+```bash
+cd tools/benchmarks && npx tsx codegen/index.ts stitches
+```
+
+### Visual and DOM parity verification
+
+After building all implementations, Playwright parity tests in `tests/parity.spec.ts` verify that every implementation produces the same output as `mochi-vanilla-react`:
+
+- **DOM parity**: the full page DOM is normalized (class names, inline styles, `id`, and `data-*` attributes are stripped) and compared textually against the `mochi-vanilla-react` baseline. 
+  Any structural divergence fails the test.
+- **Screenshot parity**: a full-page screenshot at 1280×900 is taken for each implementation and compared against a stored `baseline.png` (captured from `mochi-vanilla-react`).
+  A maximum of 2% pixel difference is allowed to account for subpixel rendering variation across platforms.
+
+To run the parity tests (implementations must already be built and served on their respective ports):
+
+```bash
+yarn workspace @mochi-css/benchmarks test
+```
+
+To update the baseline screenshot after an intentional fixture change:
+
+```bash
+cd tools/benchmarks && npx playwright test --update-snapshots --grep "mochi-vanilla-react — baseline"
+```
+
+> Only pass `--update-snapshots` together with `--grep "mochi-vanilla-react — baseline"`. Without the grep filter, all implementations' screenshots would overwrite the baseline.
+
+## Running benchmarks
+
+From the repo root:
+
+```bash
+yarn workspace @mochi-css/benchmarks benchmark
+```
+
+Results are written to `results/latest.json` and `results/latest.md`.
+
+To regenerate just the Markdown report from an existing JSON result:
+
+```bash
+yarn workspace @mochi-css/benchmarks report
+```
+
+## Latest results
+
+See [`results/latest.md`](results/latest.md) for the most recent run.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,6 +1893,7 @@ __metadata:
     "@mochi-css/test": "npm:^2.0.0"
     "@types/node": "npm:^24.8.1"
     esbuild: "npm:^0.25.0"
+    eslint: "npm:^9.39.2"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.0.15"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,6 +1883,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@mochi-css/esbuild@workspace:packages/esbuild":
+  version: 0.0.0-use.local
+  resolution: "@mochi-css/esbuild@workspace:packages/esbuild"
+  dependencies:
+    "@mochi-css/builder": "npm:^7.0.0"
+    "@mochi-css/config": "npm:^7.0.0"
+    "@mochi-css/shared-config": "npm:^2.0.0"
+    "@mochi-css/test": "npm:^2.0.0"
+    "@types/node": "npm:^24.8.1"
+    esbuild: "npm:^0.25.0"
+    typescript: "npm:^5.9.3"
+    vitest: "npm:^4.0.15"
+  peerDependencies:
+    esbuild: ^0.25
+  languageName: unknown
+  linkType: soft
+
 "@mochi-css/html-assets@workspace:tools/html-assets":
   version: 0.0.0-use.local
   resolution: "@mochi-css/html-assets@workspace:tools/html-assets"


### PR DESCRIPTION
## Summary

- New `@mochi-css/esbuild` package — esbuild plugin that statically extracts Mochi CSS at build time, supporting two output modes:
  - **Virtual mode** (default): CSS served as virtual modules, bundled into a companion `.css` file by esbuild
  - **External mode** (`externalCss: true`): CSS imports marked external and written to disk in `onEnd`, so they survive in library output JS for downstream Vite/Next.js consumers
- `tsuki` esbuild preset: detects or creates `build.mjs`, patches existing esbuild scripts to add `mochiCss()`, installs `@mochi-css/esbuild`
- 16 unit tests for the esbuild plugin; 5 new tsuki integration/smoke tests covering default script creation, existing script patching, single combined CSS output, and split-per-file CSS output